### PR TITLE
Case matters on some filesystems

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Hello from 'components/hello'
+import Hello from 'components/Hello'
 
 React.render(
   <Hello />,


### PR DESCRIPTION
```
ERROR in ./src/index.js
Module not found: Error: Cannot resolve module 'components/hello' in /home/asa/repos/React-Testing-Webpack-Tape/src
 @ ./src/index.js 11:23-50
```

I know the default Windows and Mac filesystems don't care about case, but they matter under linux. In this case it was easier to just fix the require, but I generally recommend all lowercase filenames.