### PR TITLE
Fix regular expression

### DIFF
--- a/webpack.test.bootstrap.js
+++ b/webpack.test.bootstrap.js
@@ -1,2 +1,2 @@
-var context = require.context("./src", true, /__test__\/\S+\.js$/);
+var context = require.context("./src", true, /\S+\/__test__\/\S+\.js$/);
 context.keys().forEach(context);


### PR DESCRIPTION
RegExp in webpack.test.bootstrap.js was only matching src/__test__/**/*.js and not src/**/__test__/**/*.js
